### PR TITLE
Added redux-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5",
     "redux": "^4.0.1",
+    "redux-persist": "^5.10.0",
     "redux-thunk": "^2.3.0",
     "sinon": "^6.3.4",
     "styled-components": "^4.1.1",

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,15 +1,27 @@
 import { createStore, applyMiddleware, compose } from 'redux';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'
 import thunk from 'redux-thunk';
 
 import rootReducer from './reducers';
 
+const persistConfig = {
+  key: 'root', 
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 export default function configureStore(initialState) {
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-  return createStore(
-    rootReducer,
+  let store = createStore(
+    persistedReducer,
     initialState,
     composeEnhancers(
       applyMiddleware(thunk),
     ),
   );
+
+  let persistor = persistStore(store);
+  return { store, persistor };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import './index.css';
@@ -11,17 +12,19 @@ import routes from './routes';
 import configureStore from './configureStore';
 import { loadMessages } from './actions/messageActions';
 
-const store = configureStore();
+const { persistor, store } = configureStore();
 store.dispatch(loadMessages());
 
 const AppContainer = () => (
   <MuiThemeProvider>
     <Provider store={store}>
-      <BrowserRouter>
-        <div>
-          {routes}
-        </div>
-      </BrowserRouter>
+      <PersistGate loading={ null } persistor={ persistor }>
+        <BrowserRouter>
+          <div>
+            {routes}
+          </div>
+        </BrowserRouter>
+      </PersistGate>
     </Provider>
   </MuiThemeProvider>
 );


### PR DESCRIPTION
Added redux-persist to the reducer configureStore.  Redux persist makes it so that reducer data is persisted and rehydrated after the page is reloaded.  This will make it handy so that you won't need to re-login to the app after every page load. 

More information and configuration options - https://github.com/rt2zz/redux-persist